### PR TITLE
Adding support for postgres 17

### DIFF
--- a/src/postgresql-client/devcontainer-feature.json
+++ b/src/postgresql-client/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "PostgreSQL Client",
     "id": "postgresql-client",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "PostgreSQL is a powerful, open source object-relational database system that uses and extends the SQL language combined with many features that safely store and scale the most complicated data workloads.",
     "options": {
         "version": {
@@ -10,9 +10,10 @@
                 "13",
                 "14",
                 "15",
-                "16"
+                "16",
+                "17"
             ],
-            "default": "13",
+            "default": "14",
             "description": "Select the major version of postgres"
         }
     },

--- a/src/postgresql-client/devcontainer-feature.json
+++ b/src/postgresql-client/devcontainer-feature.json
@@ -13,7 +13,7 @@
                 "16",
                 "17"
             ],
-            "default": "14",
+            "default": "13",
             "description": "Select the major version of postgres"
         }
     },

--- a/src/postgresql-client/install.sh
+++ b/src/postgresql-client/install.sh
@@ -2,7 +2,7 @@
 
 # Maintainer: John Rowley
 
-TARGET_POSTGRESQL_VERSION="${VERSION:-"14"}"
+TARGET_POSTGRESQL_VERSION="${VERSION:-"13"}"
 
 set -e
 


### PR DESCRIPTION
Added 17 as an option since it's been released.

It looks like the default is set to 14 in `install.sh`: https://github.com/robbert229/devcontainer-features/blob/a7f780d0b41e22ccbab9b3c0824849795a7be5d5/src/postgresql-client/install.sh#L5

I've changed it to reflect the default in `devcontainer-feature.json`.

Also bumped version to 1.2.0, but not sure what the right semantic is for a change like this (if it should be 1.1.1 instead?). Happy to tweak as appropriate.

Assuming that this PR will get squashed when landed. If you'd prefer I open a PR with a single commit making these changes, I can do that as well.